### PR TITLE
Setup nix-darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ $ home-manager generations
 Assuming Nix is installed, a nix-darwin configuration can be bootstrapped by running the following from the root of this repo:
 
 ```
-$ nix --experimental-features 'nix-command flakes' build --no-link .#darwinConfigurations.makani.config.system.build.toplevel
-$ "$(nix --experimental-features 'nix-command flakes' path-info .#darwinConfigurations.makani.config.system.build.toplevel)"/sw/bin/darwin-rebuild switch --flake .#makani
+$ nix --experimental-features 'nix-command flakes' build --no-link .#darwinConfigurations.makani.system
+$ "$(nix --experimental-features 'nix-command flakes' path-info .#darwinConfigurations.makani.system)"/sw/bin/darwin-rebuild switch --flake .#makani
 ```
 
 After running these commands, the `darwin-rebuild` CLI tool will be installed and available - so any further updates can be made with the usual `darwin-rebuild` CLI:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ $ home-manager generations
 Assuming Nix is installed, a nix-darwin configuration can be bootstrapped by running the following from the root of this repo:
 
 ```
-$ nix --experimental-features 'nix-command flakes' build --no-link .#darwinConfigurations.makani.system
-$ "$(nix --experimental-features 'nix-command flakes' path-info .#darwinConfigurations.makani.system)"/sw/bin/darwin-rebuild switch --flake .
+$ nix --experimental-features 'nix-command flakes' build --no-link .#darwinConfigurations.makani.config.system.build.toplevel
+$ "$(nix --experimental-features 'nix-command flakes' path-info .#darwinConfigurations.makani.config.system.build.toplevel)"/sw/bin/darwin-rebuild switch --flake .#makani
 ```
 
 After running these commands, the `darwin-rebuild` CLI tool will be installed and available - so any further updates can be made with the usual `darwin-rebuild` CLI:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains configuration for the Nix systems in my life.
 
 ## Bootstrapping
 
+### Home Manager
+
 Assuming Nix is installed, a home-manager configuration can be bootstrapped by running the following from the root of this repo:
 
 ```
@@ -22,3 +24,26 @@ $ home-manager switch --flake '.#jagd'
 
 # List configuration generations
 $ home-manager generations
+```
+
+### Nix-Darwin
+
+Assuming Nix is installed, a nix-darwin configuration can be bootstrapped by running the following from the root of this repo:
+
+```
+$ nix --experimental-features 'nix-command flakes' build --no-link .#darwinConfigurations.makani.system
+$ "$(nix --experimental-features 'nix-command flakes' path-info .#darwinConfigurations.makani.system)"/sw/bin/darwin-rebuild switch --flake .
+```
+
+After running these commands, the `darwin-rebuild` CLI tool will be installed and available - so any further updates can be made with the usual `darwin-rebuild` CLI:
+
+```
+# Build the configuration
+$ darwin-rebuild build --flake '.#makani'
+
+# Activate the configuration (building if necessary)
+$ darwin-rebuild switch --flake '.#makani'
+
+# List configuration generations
+$ darwin-rebuild generations
+```

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,27 @@
         "type": "github"
       }
     },
+    "darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1666614183,
+        "narHash": "sha256-R5+bCtUquwSfQmRBbCYc6FT6xtCaAebh0KE187e8458=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "0f90e1c34caedd0bf765ebe47b92dd1ceffafcc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -72,6 +93,7 @@
     "root": {
       "inputs": {
         "base16-shell": "base16-shell",
+        "darwin": "darwin",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "sops-nix": "sops-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -4,17 +4,21 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-    home-manager.url = "github:nix-community/home-manager";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
-
     base16-shell.url = "github:base16-project/base16-shell";
     base16-shell.flake = false;
+
+    darwin.url = "github:lnl7/nix-darwin/master";
+    darwin.inputs.nixpkgs.follows = "nixpkgs";
+
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     sops-nix.url = "github:Mic92/sops-nix";
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {
+    darwin,
     nixpkgs,
     sops-nix,
     ...
@@ -22,6 +26,16 @@
     lib = import ./lib {inherit inputs;};
   in rec {
     inherit lib;
+
+    darwinConfigurations = {
+      makani = darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        specialArgs = {inherit inputs;};
+        modules = [
+          ./hosts/makani
+        ];
+      };
+    };
 
     devShells = lib.forAllSystems (
       system: let

--- a/hosts/makani/default.nix
+++ b/hosts/makani/default.nix
@@ -6,6 +6,8 @@
   # Enable configuration for nixbld group and users
   nix.configureBuildUsers = true;
 
+  programs.zsh.enable = true;
+
   # Rnable the nix-daemon service
   services.nix-daemon.enable = true;
 

--- a/hosts/makani/default.nix
+++ b/hosts/makani/default.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  environment = {
+    loginShell = pkgs.zsh;
+  };
+
+  services.nix-daemon.enable = true;
+
+  system.defaults = {
+    NSGlobalDomain = {
+      ApplePressAndHoldEnabled = false;
+    };
+  };
+}

--- a/hosts/makani/default.nix
+++ b/hosts/makani/default.nix
@@ -1,14 +1,78 @@
-{ pkgs, ... }:
-{
+{pkgs, ...}: {
   environment = {
     loginShell = pkgs.zsh;
   };
 
+  # Enable configuration for nixbld group and users
+  nix.configureBuildUsers = true;
+
+  # Rnable the nix-daemon service
   services.nix-daemon.enable = true;
 
   system.defaults = {
     NSGlobalDomain = {
+      # Automatically switch between light and dark mode
+      AppleInterfaceStyleSwitchesAutomatically = true;
+
+      # Disable popup for character variations - allows key repeat
       ApplePressAndHoldEnabled = false;
+
+      # Show all extensions in Finder
+      AppleShowAllExtensions = true;
+
+      # How long to hold a key down before it starts repeating
+      InitialKeyRepeat = 20;
+
+      # How fast a held character repeats
+      KeyRepeat = 2;
+
+      # Disable automatic capitalisation
+      NSAutomaticCapitalizationEnabled = false;
+
+      # Disable automatic em/en-dash substitution
+      NSAutomaticDashSubstitutionEnabled = false;
+
+      # Disable smart full-stop substitution
+      NSAutomaticPeriodSubstitutionEnabled = false;
+
+      # Disable smart quote substitution
+      NSAutomaticQuoteSubstitutionEnabled = false;
+
+      # Stop trying to save new documents to iCloud
+      NSDocumentSaveNewDocumentsToCloud = false;
+
+      # Expand the save dialogue panels by default
+      NSNavPanelExpandedStateForSaveMode = true;
+      NSNavPanelExpandedStateForSaveMode2 = true;
     };
+
+    dock = {
+      autohide = true;
+
+      # Don't rearrange misson control spaces based on most recently used
+      mru-spaces = false;
+
+      orientation = "left";
+    };
+
+    finder = {
+      AppleShowAllExtensions = true;
+
+      # Default to searching the current folder
+      FXDefaultSearchScope = "SCcf";
+
+      FXEnableExtensionChangeWarning = false;
+    };
+
+    # Don't allow logins as guests
+    loginwindow.GuestEnabled = false;
+
+    # Enable tap to click
+    trackpad.Clicking = true;
+  };
+
+  system.keyboard = {
+    enableKeyMapping = true;
+    remapCapsLockToControl = true;
   };
 }


### PR DESCRIPTION
With this PR, my Mac OS-specific preferences are now managed by nix and nix-darwin.

It took me a long time to figure out that I need to set `programs.zsh.enable` to `true` in order to generate `/etc/static/zsh` and `/etc/zshrc`, which in turn cause the `bin` folder of the nix-darwin derivation in the nix store to be added to the path when creating a new interactive zsh shell!