### PR TITLE
Check files are properly formatted with `nix fmt` in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: Check code formatting
+
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
+      - name: Run linter
+        run: |
+          nix fmt
+          git diff --exit-code


### PR DESCRIPTION
This PR will run `nix fmt` (which currently uses [alejandra](https://github.com/kamadorueda/alejandra)) in GitHub actions, and then fail the workflow if there are any changes.

Currently this will only run when creating a PR, as I don't see the need to run it after I've already manually committed to main.