### PR TITLE
Make root ephemeral on basil

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,6 +1,6 @@
 keys:
   - &jagd age1525sjhkw5xg77gkt5aa5d7znmllggza3dts86et0p9ur9385dssq0n2jr5
-  - &basil age1ukypup3795x37vgke8njjvvg87sv5gsjuzxa3x9ku868du558slsmlqam6
+  - &basil age147jphxv0rm4qqsscusaw4glhyyvm9s0jvq22g5ksp8d8xrr7j5msczvu6u
 
 creation_rules:
   - path_regex: hosts/basil/secrets\.ya?ml$

--- a/flake.nix
+++ b/flake.nix
@@ -67,9 +67,8 @@
     );
 
     nixosConfigurations = {
-      basil = nixpkgs.lib.nixosSystem {
+      basil = lib.mkNixos {
         pkgs = legacyPackages.x86_64-linux;
-        specialArgs = {inherit inputs;};
         modules = [
           ./hosts/basil
         ];

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -33,6 +33,7 @@
   };
 
   users.mutableUsers = false;
+  security.sudo.wheelNeedsPassword = false;
   users.users.jagd = {
     isNormalUser = true;
     shell = pkgs.zsh;

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -10,10 +10,14 @@
   ];
 
   networking.hostName = "basil";
+  networking.hostId = "4e9cb0b8";
 
-  boot.loader.grub.enable = true;
-  boot.loader.grub.version = 2;
-  boot.loader.grub.device = "/dev/sda";
+  boot.supportedFilesystems = ["zfs"];
+  # boot.loader.grub.enable = true;
+  # boot.loader.grub.version = 2;
+  # boot.loader.grub.device = "/dev/sda";
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
 
   i18n.defaultLocale = "en_GB.UTF-8";
   time.timeZone = "Europe/London";
@@ -50,10 +54,12 @@
 
   services.openssh = {
     enable = true;
-    passwordAuthentication = false;
-    kbdInteractiveAuthentication = false;
-    permitRootLogin = "no";
+    settings = {
+      passwordAuthentication = false;
+      permitRootLogin = "no";
+      kbdInteractiveAuthentication = false;
+    };
   };
 
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
 }

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -22,6 +22,8 @@
   i18n.defaultLocale = "en_GB.UTF-8";
   time.timeZone = "Europe/London";
 
+  nixfiles.eraseYourDarlings.enable = true;
+
   nix = {
     package = pkgs.nixFlakes;
     extraOptions = ''

--- a/hosts/basil/hardware-configuration.nix
+++ b/hosts/basil/hardware-configuration.nix
@@ -9,13 +9,39 @@
   ];
 
   boot.initrd.availableKernelModules = ["ata_piix" "uhci_hcd" "virtio_pci" "virtio_scsi" "sd_mod" "sr_mod"];
-  boot.initrd.kernelModules = ["dm-snapshot"];
+  boot.initrd.kernelModules = [];
   boot.kernelModules = [];
   boot.extraModulePackages = [];
 
   fileSystems."/" = {
-    device = "/dev/disk/by-uuid/e373f129-de5b-42c7-a3c4-4c9926352e02";
-    fsType = "ext4";
+    device = "local/volatile/root";
+    fsType = "zfs";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-uuid/34EB-E578";
+    fsType = "vfat";
+  };
+
+  fileSystems."/home" = {
+    device = "local/persistent/home";
+    fsType = "zfs";
+  };
+
+  fileSystems."/nix" = {
+    device = "local/persistent/nix";
+    fsType = "zfs";
+  };
+
+  fileSystems."/persist" = {
+    device = "local/persistent/persist";
+    fsType = "zfs";
+    neededForBoot = true;
+  };
+
+  fileSystems."/var/log" = {
+    device = "local/persistent/var-log";
+    fsType = "zfs";
   };
 
   swapDevices = [];

--- a/hosts/basil/secrets.yaml
+++ b/hosts/basil/secrets.yaml
@@ -1,6 +1,6 @@
 users:
     jagd:
-        password: ENC[AES256_GCM,data:Y7yE2qx/Rg6Dm8FcDs5wKGZj72ifZFDB/zTibdPritPbH53juccxU0CPFDGNn31d1EMrXQsRKgGLJO0o2i1iIwMRZmtMUjaD62rXpXUxP8Ugta2MUXlhcBtfVdVHAu0w9/AAIsZeMHqwBA==,iv:CvxzfidsGrk74KpWGTmlA9Gwfd1SHQ2jElBzKFq7B2o=,tag:kJwhbQQ/IsZjc9Nh2JsV8g==,type:str]
+        password: ENC[AES256_GCM,data:gVoms4HsqMmyjCaaohlU4dt146RayZL64pfmlWS53JK1zcyeSckpdmW+gdtQjnIgZA5SDZNAQxzavFUY8VKdFve0Y+O8NSjw5NEcWMS5FtVASIvatz3HRqPL4Uy6f00nzj1THrPvJNCwKQ==,iv:gOL/EJ1rg2CKySWQxZ/ePPxrKybovuhVXmLvi83ofBs=,tag:IDt1DsIvw9kwMUfWUUprcA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -10,23 +10,23 @@ sops:
         - recipient: age1525sjhkw5xg77gkt5aa5d7znmllggza3dts86et0p9ur9385dssq0n2jr5
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGWFFnTjNnQVoyZk12Q2hU
-            a3NLa3RWTDQwVGVFckx6NUwwMEt6a3lyVmlvCk1WdDhCYm9PUG5zQmF2ZENYV3dF
-            SkZkZlJFRytpSFdZa3pXaGo3cTF4YmsKLS0tIGN2UmM5OG83Y0MwL1RGS01HbTht
-            c01YMmd1SFNhaUhoK3MrYWFxQXF2UEEKTaa/qur9rfmCevoagDcimxRTkaGkbGhS
-            fMH4s1dN/ssGRomEOImGEh1gRuZ1lCIwHbZ4n7JiEAhGeDdhKvuLAA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXbmxQWjA4b1d3YmRwSmNW
+            OUMyOE1RcXBxeDlpQWIyWE5qb0RvVTcvelRvCmNuUC92NGIwMms5RmVBWWxTZ1Fq
+            MHFKU05KTzNWMlNYU3ZxMm5qcDF0c1EKLS0tIGxrVnlWMGVoZ0RwcXlhQVNkS2RE
+            TW1GWUp2ZzlPdndHL0FsaWE1WmUybW8KFJqxjcx1Tv/WtYvGM3ERMzBQ/UEYdLIy
+            j64go3RoNnDihqZHqKmtMR5+nEm6bQTA8Z2yuMMAIp7OCbAHd5PA0Q==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1ukypup3795x37vgke8njjvvg87sv5gsjuzxa3x9ku868du558slsmlqam6
+        - recipient: age147jphxv0rm4qqsscusaw4glhyyvm9s0jvq22g5ksp8d8xrr7j5msczvu6u
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPWnNrZjRhRWJaMGFxMkJU
-            VExZK09YdmJjVGgyc0RrSDNIVHJEbjdYYUdzCjI1Um9EUDZjaXhBY3R0QmhnSk5G
-            RmQxVjQyWjVveVRkbEd6YmlMeXM4WWMKLS0tIGUyK0xoMjFzSnZBSEtBMHNOV1dp
-            ZDNJck13c0FpUk9MeGxodWpyVFFXdTQKXIUdTIpdrv6YdJ6u7mddTr7IneqHEKje
-            mz1HcNtXZHzgtBTQJM+7aajXTafZTEZ5etcbOdARwMhT7xhmNggXVw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNNFR0L0lXNzFvSVZENzds
+            QnBNeC8xeFdLcS9yRm8vZjFaNDFRR01yYkNBCkluaUVEcXU5Ym5WbXIvU0ZveXVZ
+            Wkl2NmNZZEZnaUViWjNPbDkzdXgwM0EKLS0tIDQzQTNHUzZuL1k5ZUFUd2VVU2Vq
+            WVhnakUrbWN0dFZKbUk1ZDZqZk9hMmsKfW5oAfoki9Hbcn3gMu5b27g8dX6J/UtY
+            kvMp2VJwVKkTwabaucODspny1Q+keZzGwEvrrQPVvKjbx8juZxxQOQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-10-04T19:59:54Z"
-    mac: ENC[AES256_GCM,data:wHrgTBpj5h3SBqE2I4kuX9pjQsV+2W9cONWnN1o7kjaBDaVDgnvdnjOIo0OWWN8zqjeUSJy9l08LQXaG8Z7Tpa9TLX54Fj8nWSOE8ukQWETu9fugEu7tLOcq7GbOif22rG26SrvAZGAvpnKmFW4bvhJlYv6J8iTZndEaIVMj1yY=,iv:iqs2qCn5jh0LyUQLcpxxhCXioQ/s42+NkRiIEIWwG4E=,tag:NNlA6UzIiLcYKWkZJjjt4g==,type:str]
+    lastmodified: "2023-02-22T14:06:22Z"
+    mac: ENC[AES256_GCM,data:e6ASTqDvkL7QMEyOP8bAhX7q5ecKhyJsbMRMk8EgGmXa5OoEjXQ/hQoB7m3wlSM7sdZl4hB36Tjxx8p1lYmEybSXEZd5i+NkwfT+/Jhk3FghVx4rTeaFSospgeQJLyf4Hs25Ix+Kbx47YBjCmMO6rR3LRl7ecywB1NUMIme8hNw=,iv:g4oWiEe4F3dGWBL6LRKoc/w6tsMD3GAHdr54SgOKBdA=,tag:RorGVRkw9FSn8tbYtYGt5w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/hosts/basil/sops.nix
+++ b/hosts/basil/sops.nix
@@ -4,7 +4,6 @@
   ];
 
   sops = {
-    age.sshKeyPaths = ["/etc/ssh/ssh_host_ed25519_key"];
     defaultSopsFile = ./secrets.yaml;
   };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,16 @@
       modules = builtins.attrValues (import ../modules/home-manager) ++ [../home/${username}];
     };
 
+  mkNixos = {
+    pkgs,
+    modules,
+  }:
+    inputs.nixpkgs.lib.nixosSystem {
+      inherit pkgs;
+      specialArgs = {inherit inputs;};
+      modules = builtins.attrValues (import ../modules/nixos) ++ modules;
+    };
+
   systems = [
     "aarch64-darwin"
     "x86_64-linux"

--- a/modules/home-manager/base16-shell.nix
+++ b/modules/home-manager/base16-shell.nix
@@ -12,8 +12,8 @@ in {
     defaultTheme = lib.mkOption {
       type = types.str;
       default = "tomorrow-night";
-      example = ''programs.base16.defaultTheme = "tomorrow-night"'';
       description = "The default theme to load if the user hasn't chosen one";
+      example = ''programs.base16.defaultTheme = "tomorrow-night"'';
     };
 
     enableZshIntegration = lib.mkEnableOption "Whether to enable base16-shell integration with zsh";

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,0 +1,3 @@
+{
+  erase-your-darlings = import ./erase-your-darlings.nix;
+}

--- a/modules/nixos/erase-your-darlings.nix
+++ b/modules/nixos/erase-your-darlings.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.nixfiles.eraseYourDarlings;
+in {
+  # For the idea behind this module, see
+  # https://grahamc.com/blog/erase-your-darlings
+
+  options.nixfiles.eraseYourDarlings = {
+    enable = lib.mkEnableOption "Whether to enable wiping / on boot";
+
+    rootSnapshot = lib.mkOption {
+      type = lib.types.str;
+      default = "local/volatile/root@blank";
+      description = "The (blank) root snapshot to restore on boot";
+      example = ''nixfiles.eraseYourDarlings.rootSnapshot = "local/volatile/root@blank"'';
+    };
+
+    persistDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/persist";
+      description = "Path to the persistent storage";
+      example = ''nixfiles.eraseYourDarlings.persistDir = "/persist"'';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Wipe / on boot
+    boot.initrd.postDeviceCommands = lib.mkAfter ''
+      zfs rollback -r ${cfg.rootSnapshot}
+    '';
+
+    # Persist /etc/machine-id so that journalctl can access logs from previous boots
+    environment.etc.machine-id = {
+      source = "${toString cfg.persistDir}/etc/machine-id";
+      mode = "0444";
+    };
+
+    # Set SSH host keys to versions in persistent storage
+    services.openssh.hostKeys = [
+      {
+        path = "${toString cfg.persistDir}/etc/ssh/ssh_host_ed25519_key";
+        type = "ed25519";
+      }
+      {
+        path = "${toString cfg.persistDir}/etc/ssh/ssh_host_rsa_key";
+        type = "rsa";
+        bits = 4096;
+      }
+    ];
+
+    # Persist /etc/nixos config
+    systemd.tmpfiles.rules = [
+      "L+ /etc/nixos - - - - ${toString cfg.persistDir}/etc/nixos"
+    ];
+  };
+}


### PR DESCRIPTION
Sets up an "[erase your darlings](https://grahamc.com/blog/erase-your-darlings)" strategy on basil.

Specifically:
 - `/` is a zfs file system that gets restored to a blank snapshot on reboot
 - `/home`, `/nix`, `/var/log` are each separate zfs file systems that are persisted between reboots
 - `/persist` is also a separate zfs file system that persists between reboots, but is where I'm going to manually put all of the state that I care about (such as SSH keys, `/etc/machine-id`, and eventually application state)