### PR TITLE
Add more basic settings for basil

### DIFF
--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -13,9 +13,6 @@
   networking.hostId = "4e9cb0b8";
 
   boot.supportedFilesystems = ["zfs"];
-  # boot.loader.grub.enable = true;
-  # boot.loader.grub.version = 2;
-  # boot.loader.grub.device = "/dev/sda";
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -71,4 +71,23 @@
 
   # Only keep the last 500MiB of systemd journal.
   services.journald.extraConfig = "SystemMaxUse=500M";
+
+  # Trimming informs the underlying storage devices of all blocks in the pool
+  # which are no longer allocated and allows thinly provisioned devices to
+  # reclaim the space.
+  # In order for auto-trim to work, it must be set on the pool:
+  # `sudo zpool set autotrim=on <pool>`
+  services.zfs.trim.enable = true;
+  services.zfs.trim.interval = "weekly";
+
+  # Scrubbing examines all data in the specified pools to verify that it
+  # checksums correctly.
+  services.zfs.autoScrub.enable = true;
+  services.zfs.autoScrub.interval = "monthly";
+
+  # Snapshots are read-only copies of a filesystem taken at a moment in time.
+  # In order for auto-snapshot to work, it must be set on the dataset:
+  # `sudo zfs set com.sun:auto-snapshot=true <dataset>`
+  services.zfs.autoSnapshot.enable = true;
+  services.zfs.autoSnapshot.monthly = 3;
 }

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -29,6 +29,11 @@
 
     # Pin nixpkgs to the same version that built the system
     registry.nixpkgs.flake = inputs.nixpkgs;
+
+    # Collect nix store garbage and optimise daily.
+    gc.automatic = true;
+    gc.options = "--delete-older-than 30d";
+    optimise.automatic = true;
   };
 
   users.mutableUsers = false;
@@ -49,6 +54,7 @@
 
   environment.systemPackages = with pkgs; [
     git
+    tree
     vim
   ];
 
@@ -62,4 +68,7 @@
   };
 
   system.stateVersion = "22.11";
+
+  # Only keep the last 500MiB of systemd journal.
+  services.journald.extraConfig = "SystemMaxUse=500M";
 }

--- a/hosts/basil/nix.nix
+++ b/hosts/basil/nix.nix
@@ -1,0 +1,20 @@
+{
+  inputs,
+  pkgs,
+  ...
+}: {
+  nix = {
+    package = pkgs.nixFlakes;
+    extraOptions = ''
+      experimental-features = nix-command flakes
+    '';
+
+    # Pin nixpkgs to the same version that built the system
+    registry.nixpkgs.flake = inputs.nixpkgs;
+
+    # Collect nix store garbage and optimise daily.
+    gc.automatic = true;
+    gc.options = "--delete-older-than 30d";
+    optimise.automatic = true;
+  };
+}

--- a/hosts/basil/users.nix
+++ b/hosts/basil/users.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  pkgs,
+  ...
+}: {
+  users.mutableUsers = false;
+
+  users.users.jagd = {
+    isNormalUser = true;
+    shell = pkgs.zsh;
+    extraGroups = ["wheel"];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBJLkRU/0rnP7dYbZ/jRrl94vaDJvTi/JbwkZLDPIQOD"
+    ];
+    passwordFile = config.sops.secrets."users/jagd/password".path;
+  };
+
+  sops.secrets."users/jagd/password" = {
+    neededForUsers = true;
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+}

--- a/hosts/basil/zfs.nix
+++ b/hosts/basil/zfs.nix
@@ -1,0 +1,22 @@
+{
+  services.zfs = {
+    # Trimming informs the underlying storage devices of all blocks in the pool
+    # which are no longer allocated and allows thinly provisioned devices to
+    # reclaim the space.
+    # In order for auto-trim to work, it must be set on the pool:
+    # `sudo zpool set autotrim=on <pool>`
+    trim.enable = true;
+    trim.interval = "weekly";
+
+    # Scrubbing examines all data in the specified pools to verify that it
+    # checksums correctly.
+    autoScrub.enable = true;
+    autoScrub.interval = "monthly";
+
+    # Snapshots are read-only copies of a filesystem taken at a moment in time.
+    # In order for auto-snapshot to work, it must be set on the dataset:
+    # `sudo zfs set com.sun:auto-snapshot=true <dataset>`
+    autoSnapshot.enable = true;
+    autoSnapshot.monthly = 3;
+  };
+}


### PR DESCRIPTION
Adds a bunch more basic config for basil, including:
 - Setting a limit on the size of logs to keep in journalctl
 - Turning on automatic garbage collection and optimisation for nix
 - Turning on automatic trimming, scrubbing and snapshotting for zfs

It also breaks out this config into a number of smaller more manageable files.