### PR TITLE
Add clone script

### DIFF
--- a/home/jagd/bin/clone
+++ b/home/jagd/bin/clone
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+read -d '' USAGE <<EOS
+Usage: $0 [-t|--temp] [--no-tmux] [-b|--branch <branch>] [-p|--ssh]
+    [-h|--help] <repo_url>"
+EOS
+
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -t|--temp)
+            TEMP="YES"
+            shift
+            ;;
+        --no-tmux)
+            NO_TMUX="YES"
+            shift
+            ;;
+        -b|--branch)
+            BRANCH=$2
+            shift
+            shift
+            ;;
+        -p|--ssh)
+            SSH="YES"
+            shift
+            ;;
+        -h|--help)
+            echo "$USAGE"
+            exit 0
+            ;;
+        -*|--*)
+            echo "Unknown arg: $1"
+            echo "$USAGE"
+            exit 1
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ ${#POSITIONAL_ARGS[@]} -ne 1 ]]; then
+    echo "Incorrect repo specification: expected 1 argument, received ${#POSITIONAL_ARGS[@]}"
+    echo "$USAGE"
+    exit 1
+fi
+
+repo_url=${POSITIONAL_ARGS[0]}
+[[ -n "$BRANCH" ]] && branch_arg="-b $BRANCH" || branch_arg=""
+
+if [[ -n $TEMP ]]; then
+    repo_name=$(basename $repo_url)
+    repo_path=$(TMPDIR="/tmp" mktemp -d -t "$repo_name-XXXXXX")
+    git clone $branch_arg $repo_url $repo_path
+else
+    [[ -n "$SSH" ]] && ssh_arg="-p" || ssh_arg=""
+    ghq get $ssh_arg $branch_arg $repo_url
+    repo_path=$(ghq list -p $repo_url)
+fi
+
+if [[ -n "$NO_TMUX" ]]; then
+    cd $repo_path
+else
+    tmux-sesh $repo_path
+fi

--- a/home/jagd/bin/tmux-sesh
+++ b/home/jagd/bin/tmux-sesh
@@ -1,18 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [[ $# -gt 0 ]]; then
-    repo_href=$(ghq list | fzf -1 -q "$*")
+if [[ -d "$*" ]]; then
+    repo_path="$*"
 else
-    repo_href=$(ghq list | fzf)
+    if [[ $# -gt 0 ]]; then
+        repo_href=$(ghq list | fzf -1 -q "$*")
+    else
+        repo_href=$(ghq list | fzf)
+    fi
+
+    if [[ -z $repo_href ]]; then
+        "Couldn't find repo $repo_href"
+        exit 1
+    fi
+
+    repo_path=$(ghq list -p -e $repo_href)
 fi
 
-if [[ -z $repo_href ]]; then
-    exit 1
-fi
-
-repo_path=$(ghq list -p -e $repo_href)
 repo_name=$(basename $repo_path)
-
 tmux_running=$(pgrep tmux)
 
 if [[ -z $tmux_running ]]; then
@@ -27,4 +32,8 @@ if ! tmux has-session -t=$repo_name 2> /dev/null; then
 fi
 
 # Attach or switch to the session
-tmux attach -t $repo_name
+if [[ -z $TMUX ]]; then
+    tmux attach -t $repo_name
+else
+    tmux switch-client -t $repo_name
+fi

--- a/home/jagd/tmux.nix
+++ b/home/jagd/tmux.nix
@@ -1,4 +1,9 @@
-{pkgs, ...}: {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
   programs.tmux = {
     enable = true;
 
@@ -42,8 +47,13 @@
     '';
   };
 
-  home.packages = let
-    clone = pkgs.writeScriptBin "clone" (builtins.readFile ./bin/clone);
-    tmuxsesh = pkgs.writeScriptBin "tmux-sesh" (builtins.readFile ./bin/tmux-sesh);
-  in [clone tmuxsesh];
+  home.file = lib.mkIf config.programs.ghq.enable {
+    "bin/clone" = {
+      source = ./bin/clone;
+    };
+
+    "bin/tmux-sesh" = {
+      source = ./bin/tmux-sesh;
+    };
+  };
 }

--- a/home/jagd/tmux.nix
+++ b/home/jagd/tmux.nix
@@ -43,6 +43,7 @@
   };
 
   home.packages = let
+    clone = pkgs.writeScriptBin "clone" (builtins.readFile ./bin/clone);
     tmuxsesh = pkgs.writeScriptBin "tmux-sesh" (builtins.readFile ./bin/tmux-sesh);
-  in [tmuxsesh];
+  in [clone tmuxsesh];
 }

--- a/home/jagd/zsh.nix
+++ b/home/jagd/zsh.nix
@@ -21,6 +21,16 @@ in {
     envExtra = ''
       export EDITOR=vim
       export VISUAL=$EDITOR
+
+      _add_to_path() {
+          if [[ -d "$1" ]] && [[ ! $PATH =~ "$1" ]]; then
+              PATH="$1:$PATH"
+          fi
+      }
+
+      _add_to_path "$HOME/bin"
+
+      export PATH
     '';
 
     initExtra = ''


### PR DESCRIPTION
Add a `clone` script for cloning git repositories and then `cd`ing into them afterwards.

Uses `ghq get` by default, which will file the git repo under the a nested directory structure in `$GHQ_ROOT`, but also supports cloning the repo into `/tmp` with the `-t` flag.

To make managing this script and other scripts easier in the future, this PR includes a small refactor to the way that scripts are "installed" with nix - they are now symlinked into `~/bin`, rather than built into a separate derivation that is then added to the `$PATH`.