### PR TITLE
Handle non-alphanumeric characters in tmux-sesh script

### DIFF
--- a/home/jagd/bin/tmux-sesh
+++ b/home/jagd/bin/tmux-sesh
@@ -17,7 +17,7 @@ else
     repo_path=$(ghq list -p -e $repo_href)
 fi
 
-repo_name=$(basename $repo_path)
+repo_name=$(basename $repo_path | sed 's/[^a-z0-9-]/_/gi')
 tmux_running=$(pgrep tmux)
 
 if [[ -z $tmux_running ]]; then

--- a/home/jagd/bin/tmux-sesh
+++ b/home/jagd/bin/tmux-sesh
@@ -22,18 +22,18 @@ tmux_running=$(pgrep tmux)
 
 if [[ -z $tmux_running ]]; then
     # If tmux isn't running, then start tmux with a new session for the repo
-    tmux new-session -s $repo_name -c $repo_path
+    tmux new-session -s "$repo_name" -c "$repo_path"
     exit 0
 fi
 
-if ! tmux has-session -t=$repo_name 2> /dev/null; then
+if ! tmux has-session -t "$repo_name" 2> /dev/null; then
     # If tmux doesn't already have a session for the repo, then create it
-    tmux new-session -d -s $repo_name -c $repo_path
+    tmux new-session -d -s "$repo_name" -c "$repo_path"
 fi
 
 # Attach or switch to the session
 if [[ -z $TMUX ]]; then
-    tmux attach -t $repo_name
+    tmux attach -t "$repo_name"
 else
-    tmux switch-client -t $repo_name
+    tmux switch-client -t "$repo_name"
 fi


### PR DESCRIPTION
The `tmux-sesh` script, used for quickly starting/attaching to a tmux session for a git repository, relied upon tmux itself to do any escaping of funky character names.

Unfortunately, it seems that tmux only does this escaping when creating a session with a given name, and not when using that name to attach to a session.

This was causing an issue with using `tmux-sesh` to create and attach to a session for my [jagd.me](https://github.com/daviesjamie/jagd.me) repo: 
 - tmux would successfully create a session with the `.` escaped - so `jagd_me`
 - tmux would then complain about not being able to attach to a session with the name `jagd.me`

This PR uses `sed` to escape non-alphanumeric characters in repository names, so that the same name can be used throughout the script.