### PR TITLE
Configure backups with Restic

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
           buildInputs = with pkgs; [
             age
             inputs.neovim.packages.${system}.default
+            restic
             sops
             ssh-to-age
           ];

--- a/hosts/basil/backups.nix
+++ b/hosts/basil/backups.nix
@@ -1,0 +1,16 @@
+{config, ...}: {
+  sops.secrets."backups/bucket/accessKey" = {};
+  sops.secrets."backups/bucket/secretKey" = {};
+  sops.secrets."backups/repo/location" = {owner = config.users.users.backups.name;};
+  sops.secrets."backups/repo/password" = {owner = config.users.users.backups.name;};
+
+  sops.templates."backups.env".content = ''
+    AWS_ACCESS_KEY_ID="${config.sops.placeholder."backups/bucket/accessKey"}"
+    AWS_SECRET_ACCESS_KEY="${config.sops.placeholder."backups/bucket/secretKey"}"
+  '';
+
+  nixfiles.backups.enable = true;
+  nixfiles.backups.environmentFile = config.sops.templates."backups.env".path;
+  nixfiles.backups.repoLocationFile = config.sops.secrets."backups/repo/location".path;
+  nixfiles.backups.repoPasswordFile = config.sops.secrets."backups/repo/password".path;
+}

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -61,8 +61,8 @@ in {
 
   sops.secrets."backups/bucket/accessKey" = {};
   sops.secrets."backups/bucket/secretKey" = {};
-  sops.secrets."backups/repo/location" = {};
-  sops.secrets."backups/repo/password" = {};
+  sops.secrets."backups/repo/location" = { owner = config.users.users.backups.name; };
+  sops.secrets."backups/repo/password" = { owner = config.users.users.backups.name; };
 
   sops.templates."backups.env".content = ''
     AWS_ACCESS_KEY_ID="${config.sops.placeholder."backups/bucket/accessKey"}"

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -57,6 +57,22 @@ in {
   nixfiles.paperless.consumeDir = "${persistDir}/paperless/consume";
   nixfiles.paperless.exportDir = "${persistDir}/paperless/export";
 
+  nixfiles.backups.enable = true;
+
+  sops.secrets."backups/bucket/accessKey" = {};
+  sops.secrets."backups/bucket/secretKey" = {};
+  sops.secrets."backups/repo/location" = {};
+  sops.secrets."backups/repo/password" = {};
+
+  sops.templates."backups.env".content = ''
+    AWS_ACCESS_KEY_ID="${config.sops.placeholder."backups/bucket/accessKey"}"
+    AWS_SECRET_ACCESS_KEY="${config.sops.placeholder."backups/bucket/secretKey"}"
+  '';
+
+  nixfiles.backups.environmentFile = config.sops.templates."backups.env".path;
+  nixfiles.backups.repoLocationFile = config.sops.secrets."backups/repo/location".path;
+  nixfiles.backups.repoPasswordFile = config.sops.secrets."backups/repo/password".path;
+
   services.caddy.enable = true;
   services.caddy.virtualHosts."paperless.jagd.me:80".extraConfig = ''
     encode gzip

--- a/hosts/basil/secrets.yaml
+++ b/hosts/basil/secrets.yaml
@@ -4,6 +4,13 @@ users:
 paperless:
     user:
         password: ENC[AES256_GCM,data:4//eQ1XQA9PsVPdzVfWAbAG5B9eCmXwQkZjT8QFzUza6hA8g8CKg+Q+dd3bmBlpF3NlbO0k56ypM/EbKpS8Aba2O3NVWNSd2UAiogUrquYjX7dB09DEnjY/j4YUZ+cncOqXPXW8QXuK00g==,iv:HVdI6pNe4EY+rOI3+duFihhdUuN1rqy5MrWUtssO4gw=,tag:hprgKPKSyWFuA+5WYTbv2w==,type:str]
+backups:
+    bucket:
+        accessKey: ENC[AES256_GCM,data:2r67HnDE+eGQc+RNLVS/ljrKZJbR3LlL0w==,iv:6CT8XSSIIhlT3b3y0QMM0A4YsPD1DpiL6BXREuRRbUY=,tag:/rxMjX2kT91/Yg4MQkZnnQ==,type:str]
+        secretKey: ENC[AES256_GCM,data:+OoKgUsTG3y4hs0O/v72vNA/THSHL7tOIufinVKP0A==,iv:2Qvcre/XSFCTq/LUWc3bLq184VrqKA/gz+k0hU6UrqI=,tag:WSg1OpAi3Z3Xesp35uSkvg==,type:str]
+    repo:
+        location: ENC[AES256_GCM,data:J0omIxt3TNxqMIJS17hDWU5GJ2xtrLsENp1OqMeZFDhs7ST9y+xpbSKsMMlOX9Ks7Q==,iv:1YECGx5BnPv7qnfO615RmhBSF/ChH+KgDUaNGTXg0EU=,tag:zryz2OoJ9QWspwAJrq1xdw==,type:str]
+        password: ENC[AES256_GCM,data:S0S7ear5jzmi/p0GszwkcpZGgzTfiHWtfh85ak+ICbH/XRFpLtKk7K0d2jzABIhvEJcJc0E=,iv:krNhK6FzbtcDoytAqBzo93vK5FGxn3Bq79WEUQcmCXI=,tag:kxOG+C5BYeH/q4GH9/eZcg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -28,8 +35,8 @@ sops:
             WVhnakUrbWN0dFZKbUk1ZDZqZk9hMmsKfW5oAfoki9Hbcn3gMu5b27g8dX6J/UtY
             kvMp2VJwVKkTwabaucODspny1Q+keZzGwEvrrQPVvKjbx8juZxxQOQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-01-21T11:25:38Z"
-    mac: ENC[AES256_GCM,data:i/JS9A3YLI/u96A/BjqJ5BF1sb7Q+K7C4rL1FdFtwU0sMBaXbhMEehhV2Y/ck6u7V4k5eMOoFNSNv8OZ5yJmTpWtNjphrVJFEq2mAwW7ntQT0rRDo6DO7ErsEVPkirIjwpqcvGBUWcfjdBRJG67EBra+eEoExZx/KFEid/0Sd5E=,iv:U9HCBqIDMGLOUgJ6+jZRW529s49DHl4FuxdsKHt6cO8=,tag:PQndnKlxceFhMkr8lZJL5w==,type:str]
+    lastmodified: "2024-02-06T22:50:54Z"
+    mac: ENC[AES256_GCM,data:jTWEtEywiEqGYiWEYRS37jzjLjZLw9LYGAvUh/MUPH1q9cAae1HauLe9O6/7BKPcwGTTKPqKeuk49vnrJvLNfDymkcgj1ppjsB6VcvXpZlRjHYUnA91SZwYiDLJiedHEnzKt49N4w1H6Ylvkw7RRbl8MhzFgVDcY6+VzpA6U7OU=,iv:aaIzCfcnG3n9wSMdxvMuQXEbtxP/vfrXeGLhPudg0q8=,tag:NLFoqhL16ou5AMybZ0rWGQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/modules/nixos/backups/default.nix
+++ b/modules/nixos/backups/default.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.nixfiles.backups;
+
+  mkSudoRule = rule: {
+    users = [config.users.users.backups.name];
+    runAs = rule.runAs;
+    commands = [
+      {
+        command = rule.command;
+        options = ["NOPASSWD"];
+      }
+    ];
+  };
+
+  mkBackup = name: options:
+    lib.nameValuePair name {
+      backupCleanupCommand = options.cleanupCommand;
+      backupPrepareCommand = options.prepareCommand;
+      environmentFile = cfg.environmentFile;
+      passwordFile = cfg.repoPasswordFile;
+      paths = options.paths;
+      pruneOpts = [
+        "--keep-daily 7"
+        "--keep-weekly 5"
+        "--keep-monthly 12"
+        "--keep-yearly 75"
+      ];
+      repositoryFile = cfg.repoLocationFile;
+      timerConfig = {
+        OnCalendar = options.startAt;
+        Persistent = true;
+        RandomizedDelaySec = options.startAtRandomDelay;
+      };
+      user = config.users.users.backups.name;
+    };
+in {
+  imports = [
+    ./options.nix
+  ];
+
+  config = lib.mkIf cfg.enable {
+    users.users.backups = {
+      description = "Backup service user";
+      isSystemUser = true;
+      group = "nogroup";
+    };
+
+    security.sudo.extraRules = map mkSudoRule cfg.sudoRules;
+
+    services.restic.backups = lib.mapAttrs' mkBackup cfg.backups;
+  };
+}

--- a/modules/nixos/backups/default.nix
+++ b/modules/nixos/backups/default.nix
@@ -24,10 +24,10 @@
       passwordFile = cfg.repoPasswordFile;
       paths = options.paths;
       pruneOpts = [
-        "--keep-daily 7"
-        "--keep-weekly 5"
-        "--keep-monthly 12"
-        "--keep-yearly 75"
+        "--keep-daily ${toString options.retention.daily}"
+        "--keep-weekly ${toString options.retention.weekly}"
+        "--keep-monthly ${toString options.retention.monthly}"
+        "--keep-yearly ${toString options.retention.yearly}"
       ];
       repositoryFile = cfg.repoLocationFile;
       timerConfig = {

--- a/modules/nixos/backups/options.nix
+++ b/modules/nixos/backups/options.nix
@@ -18,6 +18,32 @@
       description = "A script that must run after finishing the backup process";
     };
 
+    retention = {
+      daily = lib.mkOption {
+        type = lib.types.int;
+        default = 7;
+        description = "For the last n days which have one or more snapshots, keep only the most recent one for each day.";
+      };
+
+      weekly = lib.mkOption {
+        type = lib.types.int;
+        default = 5;
+        description = "for the last n weeks which have one or more snapshots, keep only the most recent one for each week.";
+      };
+
+      monthly = lib.mkOption {
+        type = lib.types.int;
+        default = 12;
+        description = "for the last n months which have one or more snapshots, keep only the most recent one for each month.";
+      };
+
+      yearly = lib.mkOption {
+        type = lib.types.int;
+        default = 75;
+        description = "for the last n years which have one or more snapshots, keep only the most recent one for each year.";
+      };
+    };
+
     startAt = lib.mkOption {
       type = lib.types.str;
       default = "daily";

--- a/modules/nixos/backups/options.nix
+++ b/modules/nixos/backups/options.nix
@@ -1,0 +1,102 @@
+{lib, ...}: let
+  backupOptions = {
+    paths = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = "The list of paths to back up";
+    };
+
+    prepareCommand = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "A script that must run before starting the backup process";
+    };
+
+    cleanupCommand = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "A script that must run after finishing the backup process";
+    };
+
+    startAt = lib.mkOption {
+      type = lib.types.str;
+      default = "daily";
+      description = "When to run the backup. See `systemd.time` for format.";
+    };
+
+    startAtRandomDelay = lib.mkOption {
+      type = lib.types.str;
+      default = "0";
+      description = "Delay starting the backup by a randomly selected amount of time between 0 and the specified value.";
+    };
+  };
+
+  sudoRuleOptions = {
+    command = lib.mkOption {
+      type = lib.types.str;
+      description = "The command for which the rule applies.";
+    };
+
+    runAs = lib.mkOption {
+      type = lib.types.str;
+      default = "ALL:ALL";
+      description = ''
+        The user / group under which the command is allowed to run.
+
+        A user can be specified using just the username: `"foo"`. It is also
+        possible to specify a user/group combination using `"foo:bar"` or to
+        only allow running as a specific group with `":bar"`.
+      '';
+    };
+  };
+in {
+  options.nixfiles.backups = {
+    backups = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule {options = backupOptions;});
+      default = {};
+      description = "Attrset of backup job definitions.";
+      example = ''
+        nixfiles.backups.backups = {
+          myService = {
+            prepareCommand = "/run/wrappers/bin/sudo myService --backup";
+            paths = [ "/persist/myService/backup" ];
+            runAt = "05:00";
+            startAtRandomDelay = "0";
+          };
+        };
+      '';
+    };
+
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to enable the backup service.";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      description = "File containing the credentials to access the repository, in the format of an EnvironmentFile as described by `systemd.exec(5)`";
+    };
+
+    repoLocationFile = lib.mkOption {
+      type = lib.types.str;
+      description = "Path to the file containing the repository location to backup to.";
+    };
+
+    repoPasswordFile = lib.mkOption {
+      type = lib.types.str;
+      description = "Path to the file containing the repository password.";
+    };
+
+    sudoRules = lib.mkOption {
+      type = lib.types.listOf (lib.types.submodule {options = sudoRuleOptions;});
+      default = [];
+      description = "List of additional sudo rules to grant the backup user.";
+      example = ''
+        nixfiles.backups.sudoRules = [
+          { command = "myService --backup" }
+        ];
+      '';
+    };
+  };
+}

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,5 @@
 {
+  backups = import ./backups;
   containers = import ./containers;
   erase-your-darlings = import ./erase-your-darlings;
   paperless = import ./paperless;


### PR DESCRIPTION
This PR adds a `backups` module that provides a convenience wrapper around backing up data using [Restic](https://restic.readthedocs.io/en/stable/) (via `services.restic.backups`).

It configures the paperless module to support these backups; so if the host paperless is running on enables the backups module, then the paperless data will be automatically backed up.

I've tested restoring the paperless backup into a fresh docker-compose stack of paperless running locally, and verified that it all works as expected.

Some other notes:
 - Backups default to `daily`, which means they run every day at midnight
 - Backup retention defaults to:
   - for the last **7 days** which have one or more snapshots, keep only the most recent one for each day
   - for the last **5 weeks** which have one or more snapshots, keep only the most recent snapshot for each week
   - for the last **12 months** which have one or more snapshots, keep only the most recent snapshot for each month
   - for the last **75 years** which have one or more snapshots, keep only the most recent snapshot for each year
 - Each time a backup is run, it actually runs:
   1. The configured `prepareCommand`, if any
   2. `restic backup`
   3. `restic forget --prune` (with the `--keep-*` arguments described above)
   4. `restic check`
   5. The configured `cleanupCommand`, if any
 - The `services.restic.backups` NixOS module automatically drops a wrapped version of the `restic` CLI tool into the PATH for each defined backup, which has all of the environment variables pre-configured. For example, to list recent snapshots for the paperless backup on basil, `sudo restic-paperless snapshots` on basil will do the trick.

Finally, at the moment I don't have any mechanism for alerting if a backup fails - this is probably something I should focus on next, as I'd like to know if my data isn't getting backed up!