### PR TITLE
Start using AdGuard Home on basil

### DIFF
--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -48,7 +48,7 @@ in {
   # Only keep the last 500MiB of systemd journal.
   services.journald.extraConfig = "SystemMaxUse=500M";
 
-  networking.firewall.allowedTCPPorts = [53 80 3123];
+  networking.firewall.allowedTCPPorts = [53 80];
   networking.firewall.allowedUDPPorts = [53];
 
   # Containers
@@ -64,6 +64,7 @@ in {
   # AdGuard Home
   nixfiles.adguardhome.enable = true;
   nixfiles.adguardhome.port = 8001;
+  nixfiles.adguardhome.exposeWizard = true;
 
   # Caddy reverse proxy
   services.caddy.enable = true;
@@ -72,7 +73,6 @@ in {
     reverse_proxy http://localhost:${toString config.nixfiles.paperless.port}
   '';
   services.caddy.virtualHosts."dns.jagd.me:80".extraConfig = ''
-    encode gzip
     reverse_proxy http://localhost:${toString config.nixfiles.adguardhome.port}
   '';
 }

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -48,6 +48,9 @@ in {
   # Only keep the last 500MiB of systemd journal.
   services.journald.extraConfig = "SystemMaxUse=500M";
 
+  networking.firewall.allowedTCPPorts = [53 80 3123];
+  networking.firewall.allowedUDPPorts = [53];
+
   # Containers
   nixfiles.containers.backend = "podman";
   nixfiles.containers.volumeBaseDir = "${persistDir}/docker-volumes";
@@ -58,11 +61,18 @@ in {
   nixfiles.paperless.consumeDir = "${persistDir}/paperless/consume";
   nixfiles.paperless.exportDir = "${persistDir}/paperless/export";
 
+  # AdGuard Home
+  nixfiles.adguardhome.enable = true;
+  nixfiles.adguardhome.port = 8001;
+
   # Caddy reverse proxy
-  networking.firewall.allowedTCPPorts = [80];
   services.caddy.enable = true;
   services.caddy.virtualHosts."paperless.jagd.me:80".extraConfig = ''
     encode gzip
     reverse_proxy http://localhost:${toString config.nixfiles.paperless.port}
+  '';
+  services.caddy.virtualHosts."dns.jagd.me:80".extraConfig = ''
+    encode gzip
+    reverse_proxy http://localhost:${toString config.nixfiles.adguardhome.port}
   '';
 }

--- a/hosts/basil/default.nix
+++ b/hosts/basil/default.nix
@@ -64,7 +64,6 @@ in {
   # AdGuard Home
   nixfiles.adguardhome.enable = true;
   nixfiles.adguardhome.port = 8001;
-  nixfiles.adguardhome.exposeWizard = true;
 
   # Caddy reverse proxy
   services.caddy.enable = true;

--- a/modules/nixos/adguardhome/default.nix
+++ b/modules/nixos/adguardhome/default.nix
@@ -20,6 +20,7 @@ in {
                 # DNS
                 host = 53;
                 inner = 53;
+                expose = true;
               }
             ]
             ++ (

--- a/modules/nixos/adguardhome/default.nix
+++ b/modules/nixos/adguardhome/default.nix
@@ -50,5 +50,9 @@ in {
         };
       };
     };
+
+    nixfiles.backups.backups.adguardhome.paths = let
+      volumeBaseDir = config.nixfiles.containers.volumeBaseDir;
+    in ["${volumeBaseDir}/adguardhome/config"];
   };
 }

--- a/modules/nixos/adguardhome/default.nix
+++ b/modules/nixos/adguardhome/default.nix
@@ -16,12 +16,9 @@ in {
           image = "adguard/adguardhome:${cfg.imageTag}";
           ports =
             [
-              {
-                # DNS
-                host = 53;
-                inner = 53;
-                expose = true;
-              }
+              # DNS
+              "0.0.0.0:53:53/tcp"
+              "0.0.0.0:53:53/udp"
             ]
             ++ (
               if cfg.exposeWizard

--- a/modules/nixos/adguardhome/default.nix
+++ b/modules/nixos/adguardhome/default.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.nixfiles.adguardhome;
+in {
+  imports = [
+    ./options.nix
+  ];
+
+  config = lib.mkIf cfg.enable {
+    nixfiles.containers.pods.adguardhome = {
+      containers = {
+        adguardhome = {
+          image = "adguard/adguardhome:${cfg.imageTag}";
+          ports = [
+            {
+              # DNS
+              host = 53;
+              inner = 53;
+            }
+            {
+              # Web interface
+              host = cfg.port;
+              inner = 80;
+            }
+            {
+              # Intro wizard interface
+              host = 3123;
+              inner = 3000;
+            }
+          ];
+          volumes = [
+            {
+              name = "data";
+              inner = "/opt/adguardhome/work";
+            }
+            {
+              name = "config";
+              inner = "/opt/adguardhome/conf";
+            }
+          ];
+        };
+      };
+    };
+  };
+}

--- a/modules/nixos/adguardhome/default.nix
+++ b/modules/nixos/adguardhome/default.nix
@@ -14,23 +14,31 @@ in {
       containers = {
         adguardhome = {
           image = "adguard/adguardhome:${cfg.imageTag}";
-          ports = [
-            {
-              # DNS
-              host = 53;
-              inner = 53;
-            }
-            {
-              # Web interface
-              host = cfg.port;
-              inner = 80;
-            }
-            {
-              # Intro wizard interface
-              host = 3123;
-              inner = 3000;
-            }
-          ];
+          ports =
+            [
+              {
+                # DNS
+                host = 53;
+                inner = 53;
+              }
+            ]
+            ++ (
+              if cfg.exposeWizard
+              then [
+                {
+                  # Initial set-up wizard
+                  host = cfg.port;
+                  inner = 3000;
+                }
+              ]
+              else [
+                {
+                  # Web interface
+                  host = cfg.port;
+                  inner = 80;
+                }
+              ]
+            );
           volumes = [
             {
               name = "data";

--- a/modules/nixos/adguardhome/options.nix
+++ b/modules/nixos/adguardhome/options.nix
@@ -6,6 +6,12 @@
       description = "Whether to enable the AdGuard Home service.";
     };
 
+    exposeWizard = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether the port for this container should route to the regular web interface or the initial set-up wizard.";
+    };
+
     imageTag = lib.mkOption {
       type = lib.types.str;
       default = "latest";

--- a/modules/nixos/adguardhome/options.nix
+++ b/modules/nixos/adguardhome/options.nix
@@ -1,0 +1,21 @@
+{lib, ...}: {
+  options.nixfiles.adguardhome = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to enable the AdGuard Home service.";
+    };
+
+    imageTag = lib.mkOption {
+      type = lib.types.str;
+      default = "latest";
+      description = "The tag to use for the `adguard/adguardhome` container image.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.int;
+      default = 8000;
+      description = "The port (on 127.0.0.1) to expose the AdGuard Home web interface on.";
+    };
+  };
+}

--- a/modules/nixos/containers/default.nix
+++ b/modules/nixos/containers/default.nix
@@ -5,9 +5,12 @@
   ...
 }: let
   mkPortDef = {
+    expose,
     host,
     inner,
-  }: "127.0.0.1:${toString host}:${toString inner}";
+  }: let
+    ip = if expose then "0.0.0.0" else "127.0.0.1";
+  in "${ip}:${toString host}:${toString inner}";
 
   mkVolumeDef = container: {
     name,

--- a/modules/nixos/containers/default.nix
+++ b/modules/nixos/containers/default.nix
@@ -4,13 +4,10 @@
   pkgs,
   ...
 }: let
-  mkPortDef = {
-    expose,
-    host,
-    inner,
-  }: let
-    ip = if expose then "0.0.0.0" else "127.0.0.1";
-  in "${ip}:${toString host}:${toString inner}";
+  mkPortDef = portCfg:
+    if builtins.typeOf portCfg == "string"
+    then portCfg
+    else "127.0.0.1:${toString portCfg.host}:${toString portCfg.inner}";
 
   mkVolumeDef = container: {
     name,

--- a/modules/nixos/containers/default.nix
+++ b/modules/nixos/containers/default.nix
@@ -4,6 +4,8 @@
   pkgs,
   ...
 }: let
+  cfg = config.nixfiles.containers;
+
   mkPortDef = portCfg:
     if builtins.typeOf portCfg == "string"
     then portCfg
@@ -121,8 +123,6 @@
           };
         })
         container.volumes));
-
-  cfg = config.nixfiles.containers;
 
   allContainers = let
     mkPodContainer = podName: pod: containerName: container:

--- a/modules/nixos/containers/options.nix
+++ b/modules/nixos/containers/options.nix
@@ -1,5 +1,11 @@
 {lib, ...}: let
   portOptions = {
+    expose = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether the port should listen on all interfaces (0.0.0.0). Default is false, and only listens on 127.0.0.1.";
+    };
+
     host = lib.mkOption {
       type = lib.types.int;
       description = "The host port (on 127.0.0.1) to expose the container port on.";

--- a/modules/nixos/containers/options.nix
+++ b/modules/nixos/containers/options.nix
@@ -1,11 +1,5 @@
 {lib, ...}: let
   portOptions = {
-    expose = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Whether the port should listen on all interfaces (0.0.0.0). Default is false, and only listens on 127.0.0.1.";
-    };
-
     host = lib.mkOption {
       type = lib.types.int;
       description = "The host port (on 127.0.0.1) to expose the container port on.";
@@ -117,9 +111,13 @@
     };
 
     ports = lib.mkOption {
-      type = lib.types.listOf (lib.types.submodule {options = portOptions;});
+      type = lib.types.listOf (lib.types.either lib.types.str (lib.types.submodule {options = portOptions;}));
       default = [];
-      description = "A list of ports to expose.";
+      description = ''
+        A list of ports to expose. Can either be attrsets describing the
+        mappings or strings which are passed verbatim to the
+        `virtualisation.oci-containers.containers.<name>.ports` setting.
+      '';
     };
 
     pullOnStart = lib.mkOption {

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,5 @@
 {
+  adguardhome = import ./adguardhome;
   backups = import ./backups;
   containers = import ./containers;
   erase-your-darlings = import ./erase-your-darlings;


### PR DESCRIPTION
This PR adds a module to run [AdGuard Home](https://github.com/AdguardTeam/AdGuardHome) in a container, and then configures basil to use that module.

Notes:
 - The web interface (port 80) is proxied through Caddy
 - If AdGuard Home starts without a config file present, it runs a wizard web interface that is served on port 3000. To access this, if needed, I added an `exposeWizard` option to the module. When `true`, it maps the configured port to port 3000 in the container instead of port 80, allowing the wizard to be accessed through the same Caddy proxy.
 - Port 53 in the container is exposed directly to UDP and TCP traffic on port 53 on the host. There is no proxying through to the container.
 - The configuration file (located in the `config` volume) is generated and updated by AdGuard from the settings web interface. This file is backed up using restic (see #10). I've deliberately chosen not to back up the other volume, as I don't really care if query history and statistics are lost.